### PR TITLE
Fixes for v0.8 and bad password handling

### DIFF
--- a/lib/yubico.js
+++ b/lib/yubico.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var http = require('http');
+var https = require('https');
 var querystring = require('querystring');
 var crypto = require('crypto');
 
@@ -193,8 +194,8 @@ Yubico.prototype._verify_token = function(otp, timeout, return_response, callbac
     var self = this;
     var otp_, nonce, query_string;
 
-    var i, client, request, host, port, path, error;
-    var timeout_ids = [], client_objects = [], request_objects = [];
+    var i, request, host, path, error;
+    var timeout_ids = [], request_objects = [];
     var got_response = false, callback_called = false;
     var client_timed_out_count = 0;
 
@@ -217,17 +218,8 @@ Yubico.prototype._verify_token = function(otp, timeout, return_response, callbac
     };
 
     var handle_got_response = function() {
-        var i, client_object, request_object, timeout_id;
+        var i, request_object, timeout_id;
         got_response = true;
-
-        for (i = 0; i < client_objects.length; i++) {
-            client_object = client_objects[i];
-            client_object.removeAllListeners('error');
-
-            if (client_object.writable) {
-                client_object.destroy();
-            }
-        }
 
         for (i = 0; i < request_objects.length; i++) {
             request_object = request_objects[i];
@@ -244,17 +236,10 @@ Yubico.prototype._verify_token = function(otp, timeout, return_response, callbac
         clearTimeout(timeout_id);
     };
 
-    var handle_response = function(response, client, timeout_id) {
+    var handle_response = function(response, timeout_id) {
         var data_buffer = [];
 
         if (got_response || callback_called) {
-            return;
-        }
-
-        if (this._use_https && !client.verifyPeer()) {
-            // Invalid SSL certificate
-            error = exceptions.InvalidSSLCertificateError(client.getPeerCertificate());
-            call_callback(error, false, null);
             return;
         }
 
@@ -337,58 +322,47 @@ Yubico.prototype._verify_token = function(otp, timeout, return_response, callbac
     };
 
     var handle_error = function(err) {
-        client.removeAllListeners('response');
         call_callback(err, false);
     };
 
-    var handle_timeout = function(client) {
+    var handle_timeout = function(request) {
         if (got_response || callback_called) {
             return;
         }
 
-        if (client.writable) {
-            client.destroy();
-        }
-
         client_timed_out_count++;
-        client.removeAllListeners('response');
+        request.removeAllListeners('response');
 
-        if (client_timed_out_count === client_objects.length) {
+        if (client_timed_out_count === request_objects.length) {
             call_callback(new exceptions.ConnectionTimeoutError(timeout));
         }
     };
 
-    port = (this._use_https) ? 443 : 80;
     for (i = 0; i < constants.API_HOSTS.length ; i++) {
         host = constants.API_HOSTS[i];
         path = sprintf('%s?%s', constants.API_PATH, query_string);
 
-        client = http.createClient(port, host, this._use_https);
-        request = client.request('GET', path, {
-            'host': host,
-            'User-Agent': sprintf('NodeJS Yubico library v%s.%s.%s',
-                                  constants.VERSION[0], constants.VERSION[1],
-                                  constants.VERSION[2])
-        });
+        if (this._use_https)
+            request = https.request({hostname: host, path: path, rejectUnauthorized: true});
+        else
+            request = http.request({hostname: host, path: path});
 
-        request.end();
-        client.on('error', handle_error);
-
-        (function(client) {
+        (function(request) {
             var timeout_id;
 
             timeout_id = setTimeout(function() {
-                handle_timeout(client);
+                handle_timeout(request);
             }, timeout);
 
             request.on('response', function(response) {
-                handle_response(response, client, timeout_id);
+                handle_response(response, timeout_id);
             });
 
             timeout_ids.push(timeout_id);
-        })(client);
+        })(request);
 
-        client_objects.push(client);
+        request.end();
+
         request_objects.push(request);
     }
 };

--- a/lib/yubico.js
+++ b/lib/yubico.js
@@ -296,19 +296,17 @@ Yubico.prototype._verify_token = function(otp, timeout, return_response, callbac
                 call_callback(null, true, response);
                 return;
             }
-            else if (status === 'no_such_client') {
+            else if (status === 'no_such_client' || status === 'bad_signature') {
                 handle_got_response();
 
                 error = new exceptions.InvaliClientError(self._client_id);
                 call_callback(error, false, response);
                 return;
             }
-            else if (status === 'replayed_otp' || status === 'bad_otp' ||
-                     status === 'bad_signature') {
+            else if (status === 'replayed_otp' || status === 'bad_otp') {
                 handle_got_response();
 
-                error = new exceptions.StatusCodeError(status);
-                call_callback(error, false, response);
+                call_callback(null, false, response);
                 return;
             }
             else if (status === 'replayed_request') {


### PR DESCRIPTION
The current code does not work on the latest stable node release. The first commit in this pull request fixes the issue by replacing deprecated http calls with their recommended replacements.

The second change modifies behavior when the password does not verify. This is not an error. When integrating into libraries like node-seq, the difference between an error and an invalid password is important. We only want to "catch" real errors that signify a service issue, and handle invalid passwords through checks of the non-error result value.
